### PR TITLE
Add yes/no options

### DIFF
--- a/dbtemplates/management/commands/sync_templates.py
+++ b/dbtemplates/management/commands/sync_templates.py
@@ -45,13 +45,9 @@ class Command(BaseCommand):
             action="store_true", dest="delete", default=False,
             help="Delete templates after syncing")
         parser.add_argument(
-            "-y", "--yes",
-            action="store_true", dest="auto_yes", default=None,
-            help="Automatically answer yes to all questions.")
-        parser.add_argument(
-            "-n", "--no",
-            action="store_true", dest="auto_no", default=None,
-            help="Automatically answer no to all questions.")
+            "-n", "--dont-ask",
+            action="store_true", dest="auto_no", default=False,
+            help="Answer no to all template creation questions. This is the opposite of --force")
 
     def handle(self, **options):
         extension = options.get('ext')
@@ -59,18 +55,7 @@ class Command(BaseCommand):
         overwrite = options.get('overwrite')
         app_first = options.get('app_first')
         delete = options.get('delete')
-        auto_yes = options.get('auto_yes')
         auto_no = options.get('auto_no')
-
-        # Can only choose -y or -n
-        if auto_no is not None and auto_yes is not None:
-            raise CommandError("The --no and --yes options are mutually exclusive, you can only choose one at a time.")
-        # If neither is chosen we prompt.
-        elif auto_no is None and auto_yes is None:
-            auto_answer = None
-        else:
-            # Otherwise if yes is set then "y", otherwise "n"
-            auto_answer = "y" if auto_yes is not None else "n"
 
         if not extension.startswith("."):
             extension = ".%s" % extension
@@ -99,8 +84,8 @@ class Command(BaseCommand):
                         t = Template.on_site.get(name__exact=name)
                     except Template.DoesNotExist:
                         if not force:
-                            if auto_answer is not None:
-                                confirm = auto_answer
+                            if auto_no:
+                                confirm = "n"
                             else:
                                 confirm = input(
                                     "\nA '%s' template doesn't exist in the "


### PR DESCRIPTION
Figured out why my libraries branding commit wasn't working, because I forgot about the dbtemplates templates that were pre-populated with the NCTR templates. 

There is a command built-in to dbtemplates to update the templates, but if there is no template found in the database for one on disk it asks you to `y/[n]` for each one. I just wanted to say yes or no (mostly no) for all.

This adds those options.